### PR TITLE
Updated Vendor Libraries and fixed Gyro ocilations

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -47,7 +47,6 @@ public class Robot extends TimedRobot {
     // Instantiate our RobotContainer.  This will perform all our button bindings, and put our
     // autonomous chooser on the dashboard.
     m_robotContainer = new RobotContainer();
-    r_Swerve = new Swerve();
 
     m_autonomousCommand = m_robotContainer.getAutonomousCommand();
   }
@@ -66,16 +65,18 @@ public class Robot extends TimedRobot {
     // and running subsystem periodic() methods.  This must be called from the robot's periodic
     // block in order for anything in the Command-based framework to work.
 
-    Pose2d a = r_Swerve.getPose();
+    //Pose2d a = r_Swerve.getPose();
     
-    SmartDashboard.putNumber("Pose X", a.getX());
-    SmartDashboard.putNumber("Pose Y", a.getY());
-    SmartDashboard.putNumber("Gyro", r_Swerve.gyro.getAngle());
+    // SmartDashboard.putNumber("Pose X", a.getX());
+    // SmartDashboard.putNumber("Pose Y", a.getY());
+    SmartDashboard.putNumber("Gyro", m_robotContainer.s_Swerve.gyro.getAngle());
+    SmartDashboard.putNumber("Converted Gyro", m_robotContainer.s_Swerve.getYaw().getDegrees());
     
     CommandScheduler.getInstance().run();
 
+
   
-    this.m_robotContainer.teleopPeriodic();
+    m_robotContainer.teleopPeriodic();
 
   }
 

--- a/vendordeps/Phoenix.json
+++ b/vendordeps/Phoenix.json
@@ -1,7 +1,7 @@
 {
     "fileName": "Phoenix.json",
     "name": "CTRE-Phoenix (v5)",
-    "version": "5.30.4+23.0.8",
+    "version": "5.30.4+23.0.10",
     "frcYear": 2023,
     "uuid": "ab676553-b602-441f-a38d-f1296eff6537",
     "mavenUrls": [
@@ -50,7 +50,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -63,7 +63,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -76,7 +76,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -89,7 +89,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -102,7 +102,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -115,7 +115,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -128,7 +128,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -141,7 +141,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -154,7 +154,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -167,7 +167,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -227,7 +227,7 @@
         {
             "groupId": "com.ctre.phoenixpro",
             "artifactId": "tools",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -287,7 +287,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "tools-sim",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -302,7 +302,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonSRX",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -317,7 +317,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simTalonFX",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "libName": "CTRE_SimTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -332,7 +332,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simVictorSPX",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -347,7 +347,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simPigeonIMU",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -362,7 +362,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simCANCoder",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "libName": "CTRE_SimCANCoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -377,7 +377,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProTalonFX",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -392,7 +392,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProCANcoder",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -407,7 +407,7 @@
         {
             "groupId": "com.ctre.phoenixpro.sim",
             "artifactId": "simProPigeon2",
-            "version": "23.0.8",
+            "version": "23.0.10",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,


### PR DESCRIPTION
Gyro Oscillation fixed.  There was a rouge line of code in robot.java that caused the gyro to be recreated multiple times.  Code was refactored to use the same one from robotcontainer.